### PR TITLE
fix: not writing single template to file on file opening

### DIFF
--- a/lua/template/internals.lua
+++ b/lua/template/internals.lua
@@ -64,7 +64,8 @@ function M.getTemplate(ft, clearBuf)
   local templateValue = localOpts.templates[ft]
 
   if #templateValue == 1 then
-    return templateValue[1].template
+    M.printToBuffer(templateValue[1].template, clearBuf)
+    return
   end
 
   vim.ui.select(M.getTemplateNames(templateValue), {


### PR DESCRIPTION
There was a minor problem with single templates after last PR, previously function was returning found template and the scope that calls it was responsible for writing template to file. I happened to overlook the statement where if only one template found, it should write it to file. 
Fixes #13 of single templates bug. 